### PR TITLE
Add schema markup option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Include these files in the head
 
 | Optional | Description |
 |----------|-------------|
-| **render** | Currently only supports reviews |
-| **min_rating** | Only display reviews with a minimum rating |
-| **max_rows** | Maximum number of rows to show |
+| **render** | Currently only supports reviews and schema |
+| **min_rating** | Only display reviews with a minimum rating (not applicable for schema)|
+| **max_rows** | Maximum number of rows to show (not applicable for schema)|
 | **rotateTime** | Time in MS to show review before rotating or false for no rotate |
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -23,12 +23,36 @@ Include these files in the head
 |----------|-------------|
 | **placeId**  | google placeId |
 
-| Optional | Description |
-|----------|-------------|
-| **render** | Currently only supports reviews and schema |
-| **min_rating** | Only display reviews with a minimum rating (not applicable for schema)|
-| **max_rows** | Maximum number of rows to show (not applicable for schema)|
-| **rotateTime** | Time in MS to show review before rotating or false for no rotate |
+| Optional | Type | Description | Default |
+|----------|----------|-------------|----------|
+| **render** | Array | Currently only supports reviews and schema | ['reviews']
+| **min_rating** | Int | Only display reviews with a minimum rating (not applicable for schema)| 0
+| **max_rows** | Int | Maximum number of rows to show - 0 for all (not applicable for schema)| 0
+| **rotateTime** | Int | Time in MS to show review before rotating or false for no rotate | false
+| **schema** | Object | Options for displaying Schema | see below |
+
+### Optional Schema Markup
+The schema markup will render something like below: 
+```
+<span itemscope="" itemtype="http://schema.org/Store">
+    <meta itemprop="url" content="http://example.com">
+    Google Users Have Rated 
+    <span itemprop="name">
+        Hostel Fish
+    </span> 
+    <span itemprop="aggregateRating" itemscope="" itemtype="http://schema.org/AggregateRating">
+        <span itemprop="ratingValue">5</span>/<span itemprop="bestRating">5</span> 
+        based on <span itemprop="ratingCount">5</span> ratings and reviews
+    </span>
+</span>
+```
+
+| Schema | Type | Description | Default |
+|----------|----------|-------------|----------|
+| **displayElement** | Object | Jquery object where the schema will be appended | {} |
+| **beforeText** | String | Text before ratings | 'Google Users Have Rated' |
+| **middleText** | String | Text in between ratings | 'based on' |
+| **afterText** | String | last text in rating | 'ratings and reviews' |
 
 ### Usage
 
@@ -39,5 +63,11 @@ $("#google-reviews").googlePlaces({
   , min_rating: 4
   , max_rows:5
   , rotateTime:5000
+  , schema: {
+          displayElement: $('#schema'),
+          beforeText: 'Googlers rated',
+          middleText: 'based on',
+          afterText: 'awesome reviewers.'
+      }
 });
 ```

--- a/google-places.js
+++ b/google-places.js
@@ -9,6 +9,12 @@
             , min_rating: 0
             , max_rows: 0
             , rotateTime: false
+            ,schema:{
+                displayElement: {},
+                beforeText: 'Google Users Have Rated',
+                middleText: 'base on',
+                afterText: 'ratings and reviews'
+            }
         };
 
         var plugin = this;
@@ -31,8 +37,8 @@
               }
             }
             // render schema markup
-            if(plugin.settings.render.indexOf('schema') > -1){
-                getSchemaMarkup(plugin.place_data);
+            if(plugin.settings.schema.displayElement instanceof jQuery){
+                addSchemaMarkup(plugin.place_data);
             }
           });
         }
@@ -130,7 +136,7 @@
           return time;
         }
         
-        var getSchemaMarkup = function(placeData) {
+        var addSchemaMarkup = function(placeData) {
           var reviews = placeData.reviews;
           var lastIndex = reviews.length - 1;
           var reviewPointTotal = 0;
@@ -139,12 +145,13 @@
           };
           // Set totals and averages - may be used later.
           var averageReview = reviewPointTotal / ( reviews.length );
-            $element.append( '<span itemscope="" itemtype="http://schema.org/Store">'
+            plugin.settings.schema.displayElement.append( '<span itemscope="" itemtype="http://schema.org/Store">'
             +  '<meta itemprop="url" content="' + location.origin + '">'
-            +  'Google users have rated <span itemprop="name">' + placeData.name + '</span> '
+            +  plugin.settings.schema.beforeText + ' <span itemprop="name">' + placeData.name + '</span> '
             +  '<span itemprop="aggregateRating" itemscope="" itemtype="http://schema.org/AggregateRating">'
-            +    '<span itemprop="ratingValue">' + averageReview + '</span>/<span itemprop="bestRating">5</span>'
-            +    ' based on <span itemprop="ratingCount">' + reviews.length + '</span> ratings and reviews'
+            +    '<span itemprop="ratingValue">' + averageReview + '</span>/<span itemprop="bestRating">5</span> '
+            +  plugin.settings.schema.middleText + ' <span itemprop="ratingCount">' + reviews.length + '</span> '
+            +  plugin.settings.schema.afterText
             +  '</span>'
             +'</span>');
         }

--- a/google-places.js
+++ b/google-places.js
@@ -86,7 +86,6 @@
             var date = convertTime(reviews[i].time);
             html = html+"<div class='review-item'><div class='review-meta'><span class='review-author'>"+reviews[i].author_name+"</span><span class='review-sep'>, </span><span class='review-date'>"+date+"</span></div>"+stars+"<p class='review-text'>"+reviews[i].text+"</p></div>"
           };
-          // Set totals and averages - may be used later.
           $element.append(html);
         }
         

--- a/google-places.js
+++ b/google-places.js
@@ -30,6 +30,10 @@
                   initRotation();
               }
             }
+            // render schema markup
+            if(plugin.settings.render.indexOf('schema') > -1){
+                getSchemaMarkup(plugin.place_data);
+            }
           });
         }
 
@@ -75,13 +79,18 @@
           reviews = filter_minimum_rating(reviews);
           var html = "";
           var row_count = (plugin.settings.max_rows > 0)? plugin.settings.max_rows - 1 : reviews.length - 1;
+          var reviewPointTotal = 0;
           // make sure the row_count is not greater than available records
           row_count = (row_count > reviews.length)? reviews.length -1 : row_count;
           for (var i = row_count; i >= 0; i--) {
             var stars = renderStars(reviews[i].rating);
+            reviewPointTotal += reviews[i].rating;
             var date = convertTime(reviews[i].time);
             html = html+"<div class='review-item'><div class='review-meta'><span class='review-author'>"+reviews[i].author_name+"</span><span class='review-sep'>, </span><span class='review-date'>"+date+"</span></div>"+stars+"<p class='review-text'>"+reviews[i].text+"</p></div>"
           };
+          // Set totals and averages - may be used later.
+          numReviews = row_count;
+          averageReview = reviewPointTotal / numReviews;
           $element.append(html);
         }
         
@@ -125,9 +134,27 @@
           var time = months[a.getMonth()] + ' ' + a.getDate() + ', ' + a.getFullYear();
           return time;
         }
-
+        
+        var getSchemaMarkup = function(placeData) {
+          var reviews = placeData.reviews;
+          var row_count = reviews.length - 1;
+          var reviewPointTotal = 0;
+          for (var i = row_count; i >= 0; i--) {
+            reviewPointTotal += reviews[i].rating;
+          };
+          // Set totals and averages.
+          var averageReview = reviewPointTotal / ( reviews.length );
+            $element.append( '<span itemscope="" itemtype="http://schema.org/Store">'
+            +  '<meta itemprop="url" content="' + location.origin + '">'
+            +  'Google users have rated <span itemprop="name">' + placeData.name + '</span> '
+            +  '<span itemprop="aggregateRating" itemscope="" itemtype="http://schema.org/AggregateRating">'
+            +    '<span itemprop="ratingValue">' + averageReview + '</span>/<span itemprop="bestRating">5</span>'
+            +    ' based on <span itemprop="ratingCount">' + reviews.length + '</span> ratings and reviews'
+            +  '</span>'
+            +'</span>');
+        }
+        
         plugin.init();
-
     }
 
     $.fn.googlePlaces = function(options) {

--- a/google-places.js
+++ b/google-places.js
@@ -12,7 +12,7 @@
             ,schema:{
                 displayElement: {},
                 beforeText: 'Google Users Have Rated',
-                middleText: 'base on',
+                middleText: 'based on',
                 afterText: 'ratings and reviews'
             }
         };

--- a/google-places.js
+++ b/google-places.js
@@ -79,18 +79,14 @@
           reviews = filter_minimum_rating(reviews);
           var html = "";
           var row_count = (plugin.settings.max_rows > 0)? plugin.settings.max_rows - 1 : reviews.length - 1;
-          var reviewPointTotal = 0;
           // make sure the row_count is not greater than available records
           row_count = (row_count > reviews.length)? reviews.length -1 : row_count;
           for (var i = row_count; i >= 0; i--) {
             var stars = renderStars(reviews[i].rating);
-            reviewPointTotal += reviews[i].rating;
             var date = convertTime(reviews[i].time);
             html = html+"<div class='review-item'><div class='review-meta'><span class='review-author'>"+reviews[i].author_name+"</span><span class='review-sep'>, </span><span class='review-date'>"+date+"</span></div>"+stars+"<p class='review-text'>"+reviews[i].text+"</p></div>"
           };
           // Set totals and averages - may be used later.
-          numReviews = row_count;
-          averageReview = reviewPointTotal / numReviews;
           $element.append(html);
         }
         
@@ -137,12 +133,12 @@
         
         var getSchemaMarkup = function(placeData) {
           var reviews = placeData.reviews;
-          var row_count = reviews.length - 1;
+          var lastIndex = reviews.length - 1;
           var reviewPointTotal = 0;
-          for (var i = row_count; i >= 0; i--) {
+          for (var i = lastIndex; i >= 0; i--) {
             reviewPointTotal += reviews[i].rating;
           };
-          // Set totals and averages.
+          // Set totals and averages - may be used later.
           var averageReview = reviewPointTotal / ( reviews.length );
             $element.append( '<span itemscope="" itemtype="http://schema.org/Store">'
             +  '<meta itemprop="url" content="' + location.origin + '">'
@@ -155,6 +151,7 @@
         }
         
         plugin.init();
+        
     }
 
     $.fn.googlePlaces = function(options) {


### PR DESCRIPTION
Addition of a new render option to print the schema.ord markup for aggregate rating using the data returned from places api

@peledies I am not sure about a couple things

1. Should the render option be allowed to print both the reviews, and the schema, or should they be separated?
2. I'm not sure about using language in the code directly, should we make the English parts of the markup an option that can be changed?

